### PR TITLE
Fix android v1 embedding by adding local wallpaper plugin

### DIFF
--- a/packages/wallpaper_manager_flutter/README.md
+++ b/packages/wallpaper_manager_flutter/README.md
@@ -1,0 +1,5 @@
+# Wallpaper Manager Flutter
+
+This is a lightweight plugin used by the app to set wallpapers on Android devices.
+It uses the Android v2 embedding and exposes a single method to set a wallpaper
+from a file for the home screen, lock screen, or both.

--- a/packages/wallpaper_manager_flutter/android/src/main/kotlin/com/example/wallpaper_manager_flutter/WallpaperManagerFlutterPlugin.kt
+++ b/packages/wallpaper_manager_flutter/android/src/main/kotlin/com/example/wallpaper_manager_flutter/WallpaperManagerFlutterPlugin.kt
@@ -1,0 +1,61 @@
+package com.example.wallpaper_manager_flutter
+
+import android.app.WallpaperManager
+import android.content.Context
+import android.graphics.BitmapFactory
+import androidx.annotation.NonNull
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+import java.io.File
+
+class WallpaperManagerFlutterPlugin : FlutterPlugin, MethodCallHandler {
+  private lateinit var channel: MethodChannel
+  private lateinit var context: Context
+
+  override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    channel = MethodChannel(binding.binaryMessenger, "wallpaper_manager_flutter")
+    channel.setMethodCallHandler(this)
+    context = binding.applicationContext
+  }
+
+  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    channel.setMethodCallHandler(null)
+  }
+
+  override fun onMethodCall(call: MethodCall, result: Result) {
+    if (call.method == "setWallpaper") {
+      val filePath = call.argument<String>("filePath")
+      val location = call.argument<Int>("location") ?: 1
+      if (filePath == null) {
+        result.error("INVALID_ARGUMENT", "filePath is required", null)
+        return
+      }
+      val file = File(filePath)
+      if (!file.exists()) {
+        result.error("FILE_NOT_FOUND", "File not found", null)
+        return
+      }
+      val bitmap = BitmapFactory.decodeFile(filePath)
+      val wm = WallpaperManager.getInstance(context)
+      try {
+        when (location) {
+          1 -> wm.setBitmap(bitmap, null, true, WallpaperManager.FLAG_SYSTEM)
+          2 -> wm.setBitmap(bitmap, null, true, WallpaperManager.FLAG_LOCK)
+          3 -> {
+            wm.setBitmap(bitmap, null, true, WallpaperManager.FLAG_SYSTEM)
+            wm.setBitmap(bitmap, null, true, WallpaperManager.FLAG_LOCK)
+          }
+          else -> wm.setBitmap(bitmap)
+        }
+        result.success(null)
+      } catch (e: Exception) {
+        result.error("SET_WALLPAPER_FAILED", e.message, null)
+      }
+    } else {
+      result.notImplemented()
+    }
+  }
+}

--- a/packages/wallpaper_manager_flutter/lib/wallpaper_manager_flutter.dart
+++ b/packages/wallpaper_manager_flutter/lib/wallpaper_manager_flutter.dart
@@ -1,0 +1,19 @@
+library wallpaper_manager_flutter;
+
+import 'dart:io';
+import 'package:flutter/services.dart';
+
+class WallpaperManagerFlutter {
+  static const MethodChannel _channel = MethodChannel('wallpaper_manager_flutter');
+
+  static const int HOME_SCREEN = 1;
+  static const int LOCK_SCREEN = 2;
+  static const int BOTH_SCREENS = 3;
+
+  Future<void> setwallpaperfromFile(File file, int location) async {
+    await _channel.invokeMethod('setWallpaper', {
+      'filePath': file.path,
+      'location': location,
+    });
+  }
+}

--- a/packages/wallpaper_manager_flutter/pubspec.yaml
+++ b/packages/wallpaper_manager_flutter/pubspec.yaml
@@ -1,0 +1,11 @@
+name: wallpaper_manager_flutter
+description: Simple wallpaper setting plugin using Android v2 embedding.
+version: 0.0.1
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: com.example.wallpaper_manager_flutter
+        pluginClass: WallpaperManagerFlutterPlugin

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1229,11 +1229,10 @@ packages:
   wallpaper_manager_flutter:
     dependency: "direct main"
     description:
-      name: wallpaper_manager_flutter
-      sha256: "37286f08293ec62590448599b7dc3b94b11ee1175ab7b0e33cbf6b79fbfcba42"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.2"
+      path: packages/wallpaper_manager_flutter
+      relative: true
+    source: path
+    version: "0.0.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,8 @@ dependencies:
   font_awesome_flutter: ^10.8.0
   xml: ^6.5.0
   share_plus: ^11.0.0
-  wallpaper_manager_flutter: ^0.0.2
+  wallpaper_manager_flutter:
+    path: packages/wallpaper_manager_flutter
   flutter_bloc: ^8.1.5
   equatable: ^2.0.5
   get_it: ^7.6.7


### PR DESCRIPTION
## Summary
- remove old wallpaper plugin dependency
- add local `wallpaper_manager_flutter` plugin using Android v2 embedding

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887663c9404832a9e636ad5cc33e729