### PR TITLE
Add missing Android build files for wallpaper_manager_flutter plugin

### DIFF
--- a/packages/wallpaper_manager_flutter/android/build.gradle
+++ b/packages/wallpaper_manager_flutter/android/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id "com.android.library"
+    id "org.jetbrains.kotlin.android"
+    id "dev.flutter.plugin.flutter-plugin"
+}
+
+android {
+    compileSdkVersion flutter.compileSdkVersion
+    namespace "com.example.wallpaper_manager_flutter"
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+
+    defaultConfig {
+        minSdkVersion flutter.minSdkVersion
+    }
+}
+
+flutter {
+    source '../..'
+}
+

--- a/packages/wallpaper_manager_flutter/android/src/main/AndroidManifest.xml
+++ b/packages/wallpaper_manager_flutter/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.example.wallpaper_manager_flutter" />


### PR DESCRIPTION
## Summary
- include Android build configuration for the local `wallpaper_manager_flutter` plugin
- add minimal Android manifest for the plugin

## Testing
- `gradle` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876c101d58832aac5870b0e3594f70