### PR TITLE
Fix adhkar notification permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Permissions required for showing scheduled notifications on Android 13+ -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application
         android:label="azkar"
         android:name="${applicationName}"

--- a/lib/AdhkarReminderPage.dart
+++ b/lib/AdhkarReminderPage.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'AdhkarReminderManager.dart';
 
 class AdhkarReminderPage extends StatefulWidget {
@@ -31,6 +32,12 @@ class _AdhkarReminderPageState extends State<AdhkarReminderPage> {
       final status = await Permission.notification.request();
       debugPrint("Notification permission status: $status");
     }
+
+    // اطلب الإذن أيضاً من flutter_local_notifications في حال كان مطلوباً
+    await AdhkarReminderManager.flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestPermission();
   }
 
   Future<void> loadSettings() async {


### PR DESCRIPTION
## Summary
- add required notification permissions on Android
- request permission through the notifications plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887809c0a98832aa1ac6b5692e08102