### PR TITLE
Fix audio service initialization

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,17 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <service
+            android:name="com.ryanheise.audioservice.AudioService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback"
+            tools:ignore="Instantiatable" />
+
+        <service
+            android:name="com.ryanheise.just_audio_background.JustAudioBackgroundService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback"
+            tools:ignore="Instantiatable" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data


### PR DESCRIPTION
## Summary
- add AudioService and JustAudioBackgroundService to Android manifest

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888809f9d2c832ab8227f42bd9e2c98