### PR TITLE
Remove deprecated UMP plugin and use Google Mobile Ads consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The "Azkar Alafasi App" is a comprehensive application developed using Flutter, 
     - Support for Light and Dark modes.
     - Ability to increase or decrease font size on the text reader page.
 - **🌍 Multi-Platform Support:** Built with Flutter, allowing it to run on Android, iOS, Web, Windows, macOS, and Linux.
-- **💰 Monetization:** The app includes AdMob ads to support its development and sustainability, while respecting user experience and displaying User Messaging Platform (UMP) consent forms.
+- **💰 Monetization:** The app includes AdMob ads to support its development and sustainability, while respecting user experience and displaying consent forms through Google Mobile Ads.
 - **🔔 Firebase Notifications:** Receive important notifications and updates.
 
 ## 📸 Screenshots
@@ -70,8 +70,7 @@ The "Azkar Alafasi App" is a comprehensive application developed using Flutter, 
 - **Permissions:**
     - `permission_handler`: For requesting permissions (notifications, location, storage).
 - **Ads:**
-    - `google_mobile_ads`: For displaying AdMob ads (banner, interstitial, native, and rewarded).
-    - `user_messaging_platform`: For managing user consent for ads.
+    - `google_mobile_ads`: For displaying AdMob ads (banner, interstitial, native, and rewarded) and managing user consent.
 - **UI & Utilities:**
     - `flutter_localization`: For multi-language support (the app currently focuses on Arabic).
     - `url_launcher`: To open external links (e.g., rate app, privacy policy).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:timezone/data/latest.dart' as tz;
-import 'package:user_messaging_platform/user_messaging_platform.dart' as UMP;
 import 'package:firebase_in_app_messaging/firebase_in_app_messaging.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:http/http.dart' as http;
@@ -63,22 +62,20 @@ Future<void> main() async {
 }
 
 Future<void> _initConsentForAds() async {
-  final UMP.ConsentRequestParameters params = UMP.ConsentRequestParameters();
+  final params = ConsentRequestParameters();
+  final consentInfo = ConsentInformation.instance;
 
   try {
-    var consentInfo = await UMP.UserMessagingPlatform.instance.requestConsentInfoUpdate(params);
+    await consentInfo.requestConsentInfoUpdate(params);
 
-    if (consentInfo.consentStatus == UMP.ConsentStatus.required) {
-      consentInfo = await UMP.UserMessagingPlatform.instance.showConsentForm();
+    if (await consentInfo.isConsentFormAvailable()) {
+      final form = await ConsentForm.loadConsentForm();
+      await form.show();
+    }
 
-      if (consentInfo.consentStatus == UMP.ConsentStatus.obtained) {
-        print("حصلنا على موافقة مخصصة (Personalized Ads).");
-      } else {
-        print("المستخدم لم يمنح موافقة مخصصة.");
-      }
-    } else if (consentInfo.consentStatus == UMP.ConsentStatus.obtained) {
-      print("موافقة مخصصة موجودة مسبقًا.");
-    } else if (consentInfo.consentStatus == UMP.ConsentStatus.notRequired) {
+    if (consentInfo.consentStatus == ConsentStatus.obtained) {
+      print("حصلنا على موافقة مخصصة (Personalized Ads).");
+    } else if (consentInfo.consentStatus == ConsentStatus.notRequired) {
       print("لا حاجة لعرض نموذج الموافقة.");
     } else {
       print("حالة الموافقة الحالية: ${consentInfo.consentStatus}");

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1282,14 +1282,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.4"
-  user_messaging_platform:
-    dependency: "direct main"
-    description:
-      name: user_messaging_platform
-      sha256: "4843f6a6d92e12ed72eeb1acac7694f9fdd82ec7deac10cae9c0b2d7535d62e9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   firebase_messaging: ^15.2.2
   connectivity_plus: ^6.1.2
   url_launcher: ^6.3.1
-  user_messaging_platform: ^1.3.0
   firebase_in_app_messaging: ^0.8.1+4
   geolocator: ^13.0.2
   adhan: ^2.0.0+1


### PR DESCRIPTION
## Summary
- remove `user_messaging_platform` dependency and docs
- use Google Mobile Ads' consent APIs for ad consent

## Testing
- `flutter pub get` *(command not found: flutter)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d890f65c832aa9afc82c60dd2aa6