### PR TITLE
refactor: use AppConstants for ad unit ids

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -28,6 +28,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../wallpapers_page.dart';
 import 'routing.dart';
+import '../core/constants/app_constants.dart';
 
 final GlobalKey<MyAppState> myAppKey = GlobalKey<MyAppState>();
 
@@ -72,7 +73,7 @@ class _NativeAdWidgetState extends State<NativeAdWidget> {
 
   void _loadAd() {
     _nativeAd = NativeAd(
-      adUnitId: 'ca-app-pub-7223999276472548/6597309308', // Production Ad Unit ID
+      adUnitId: AppConstants.nativeAdUnitId, // Production Ad Unit ID
       factoryId: 'listTile',
       request: const AdRequest(),
       listener: NativeAdListener(
@@ -1153,7 +1154,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   /// تحميل إعلان البانر
   void loadBannerAd() {
     _bannerAd = BannerAd(
-      adUnitId: 'ca-app-pub-7223999276472548/9615774793',
+      adUnitId: AppConstants.bannerAdUnitId,
       size: AdSize.banner,
       request: const AdRequest(),
       listener: BannerAdListener(
@@ -1169,7 +1170,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   /// تحميل إعلان انتقالي (Interstitial)
   void loadInterstitialAd() {
     InterstitialAd.load(
-      adUnitId: 'ca-app-pub-7223999276472548/6569146925',
+      adUnitId: AppConstants.interstitialAdUnitId,
       request: const AdRequest(),
       adLoadCallback: InterstitialAdLoadCallback(
         onAdLoaded: (ad) => _interstitialAd = ad,
@@ -1181,7 +1182,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   /// تحميل إعلان مكافآت (Rewarded)
   void loadRewardedAd() {
     RewardedAd.load(
-      adUnitId: 'ca-app-pub-7223999276472548/7762749023',
+      adUnitId: AppConstants.rewardedAdUnitId,
       request: const AdRequest(),
       rewardedAdLoadCallback: RewardedAdLoadCallback(
         onAdLoaded: (ad) => _rewardedAd = ad,
@@ -2388,7 +2389,7 @@ class AppOpenAdManager {
 
   void loadAd() {
     AppOpenAd.load(
-      adUnitId: 'ca-app-pub-7223999276472548/1510060234',
+      adUnitId: AppConstants.appOpenAdUnitId,
       request: const AdRequest(),
       adLoadCallback: AppOpenAdLoadCallback(
         onAdLoaded: (ad) {

--- a/lib/wallpapers_page.dart
+++ b/lib/wallpapers_page.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:wallpaper_manager_flutter/wallpaper_manager_flutter.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'core/constants/app_constants.dart';
 
 class WallpapersPage extends StatefulWidget {
   @override
@@ -29,7 +30,7 @@ class _WallpapersPageState extends State<WallpapersPage> {
 
   void _loadBannerAd() {
     _bannerAd = BannerAd(
-      adUnitId: 'ca-app-pub-7223999276472548/9615774793', // نفس الموجود في main
+      adUnitId: AppConstants.bannerAdUnitId, // نفس الموجود في main
       size: AdSize.banner,
       request: const AdRequest(),
       listener: BannerAdListener(
@@ -148,7 +149,7 @@ class _FullImageViewState extends State<FullImageView> {
 
   void _loadBannerAd() {
     _bannerAd = BannerAd(
-      adUnitId: 'ca-app-pub-7223999276472548/9615774793',
+      adUnitId: AppConstants.bannerAdUnitId,
       size: AdSize.banner,
       request: const AdRequest(),
       listener: BannerAdListener(
@@ -177,7 +178,7 @@ class _FullImageViewState extends State<FullImageView> {
 
   void _loadInterstitialAd() {
     InterstitialAd.load(
-      adUnitId: 'ca-app-pub-7223999276472548/6569146925',
+      adUnitId: AppConstants.interstitialAdUnitId,
       request: const AdRequest(),
       adLoadCallback: InterstitialAdLoadCallback(
         onAdLoaded: (ad) => _interstitialAd = ad,


### PR DESCRIPTION
## Summary
- replace hardcoded ad unit strings with AppConstants references in app.dart and wallpapers_page.dart
- import AppConstants to centralize ad configuration

## Testing
- `dart format lib/app/app.dart lib/wallpapers_page.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c83883bfa8832a84b9d85454786627