### PR TITLE
Wire audio player streams to bloc and test disposal

### DIFF
--- a/lib/core/services/audio_service.dart
+++ b/lib/core/services/audio_service.dart
@@ -9,18 +9,27 @@ import 'package:path_provider/path_provider.dart';
 import '../models/supplication.dart';
 
 class AudioService {
-  final AudioPlayer _audioPlayer = AudioPlayer();
+  AudioService({AudioPlayer? audioPlayer}) : _audioPlayer = audioPlayer ?? AudioPlayer();
+
+  final AudioPlayer _audioPlayer;
   final Map<String, String> _youtubeCache = {};
-  
+
   StreamSubscription<ProcessingState>? _processingStateSubscription;
   StreamSubscription<bool>? _playingStreamSubscription;
 
   AudioPlayer get audioPlayer => _audioPlayer;
   Map<String, String> get youtubeCache => _youtubeCache;
 
-  void initialize() {
-    _processingStateSubscription = _audioPlayer.processingStateStream.listen(null);
-    _playingStreamSubscription = _audioPlayer.playingStream.listen(null);
+  void initialize({
+    void Function(ProcessingState state)? onProcessingStateChanged,
+    void Function(bool playing)? onPlayingChanged,
+  }) {
+    _processingStateSubscription = onProcessingStateChanged == null
+        ? null
+        : _audioPlayer.processingStateStream.listen(onProcessingStateChanged);
+    _playingStreamSubscription = onPlayingChanged == null
+        ? null
+        : _audioPlayer.playingStream.listen(onPlayingChanged);
   }
 
   Future<void> setAudioSource(Supplication supplication) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   build_runner: ^2.4.9
   injectable_generator: ^2.6.1
+  mocktail: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/test/core/services/audio_service_test.dart
+++ b/test/core/services/audio_service_test.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:just_audio/just_audio.dart';
+
+import 'package:azkar/core/services/audio_service.dart';
+
+class MockAudioPlayer extends Mock implements AudioPlayer {}
+
+void main() {
+  test('dispose cancels subscriptions', () async {
+    final mockPlayer = MockAudioPlayer();
+    final processingController = StreamController<ProcessingState>.broadcast();
+    final playingController = StreamController<bool>.broadcast();
+
+    when(() => mockPlayer.processingStateStream)
+        .thenAnswer((_) => processingController.stream);
+    when(() => mockPlayer.playingStream)
+        .thenAnswer((_) => playingController.stream);
+    when(() => mockPlayer.dispose()).thenAnswer((_) async {});
+
+    final service = AudioService(audioPlayer: mockPlayer);
+
+    int processingCalls = 0;
+    int playingCalls = 0;
+
+    service.initialize(
+      onProcessingStateChanged: (_) => processingCalls++,
+      onPlayingChanged: (_) => playingCalls++,
+    );
+
+    processingController.add(ProcessingState.ready);
+    playingController.add(true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(processingCalls, 1);
+    expect(playingCalls, 1);
+
+    service.dispose();
+
+    expect(processingController.hasListener, isFalse);
+    expect(playingController.hasListener, isFalse);
+
+    await processingController.close();
+    await playingController.close();
+  });
+}


### PR DESCRIPTION
## Summary
- add optional callbacks to `AudioService` and listen to player streams
- propagate playback and processing updates to `AudioBloc`
- test that `AudioService.dispose` cancels stream subscriptions

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c839c1c56c832a8ff0e24917fc4894