### PR TITLE
Improve wallpapers error handling

### DIFF
--- a/lib/features/wallpapers/cubit/wallpapers_cubit.dart
+++ b/lib/features/wallpapers/cubit/wallpapers_cubit.dart
@@ -36,10 +36,15 @@ class WallpapersCubit extends Cubit<WallpapersState> {
         status: WallpapersStatus.success,
         images: images,
       ));
+    } on WallpapersException catch (error) {
+      emit(state.copyWith(
+        status: WallpapersStatus.failure,
+        errorMessage: error.message,
+      ));
     } catch (error) {
       emit(state.copyWith(
         status: WallpapersStatus.failure,
-        errorMessage: error.toString(),
+        errorMessage: 'تعذر تحميل الخلفيات. الرجاء المحاولة لاحقاً.',
       ));
     }
   }

--- a/lib/features/wallpapers/data/services/wallpapers_service.dart
+++ b/lib/features/wallpapers/data/services/wallpapers_service.dart
@@ -5,6 +5,15 @@ import 'package:xml/xml.dart';
 
 import '../models/blog_image.dart';
 
+class WallpapersException implements Exception {
+  const WallpapersException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 class WallpapersService {
   WallpapersService({http.Client? client}) : _client = client ?? http.Client();
 
@@ -14,33 +23,44 @@ class WallpapersService {
   final http.Client _client;
 
   Future<List<BlogImage>> fetchWallpapers() async {
-    final response = await _client.get(Uri.parse(_feedUrl));
-    if (response.statusCode != 200) {
-      throw Exception('فشل في جلب الصور (${response.statusCode})');
-    }
-
-    final document = XmlDocument.parse(response.body);
-    final entries = document.findAllElements('entry');
-
-    final images = <BlogImage>[];
-
-    for (final entry in entries) {
-      final title = entry.getElement('title')?.innerText ?? 'بدون عنوان';
-      final content = entry.getElement('content')?.innerText ?? '';
-
-      final match = RegExp(r'<img[^>]+src="([^">]+)"').firstMatch(content);
-      if (match != null) {
-        images.add(BlogImage(title: title, imageUrl: match.group(1)!));
+    try {
+      final response = await _client.get(Uri.parse(_feedUrl));
+      if (response.statusCode != 200) {
+        throw WallpapersException(
+          'فشل في جلب الخلفيات (رمز الاستجابة: ${response.statusCode})',
+        );
       }
-    }
 
-    return images;
+      final document = XmlDocument.parse(response.body);
+      final entries = document.findAllElements('entry');
+
+      final images = <BlogImage>[];
+
+      for (final entry in entries) {
+        final title = entry.getElement('title')?.innerText ?? 'بدون عنوان';
+        final content = entry.getElement('content')?.innerText ?? '';
+
+        final match = RegExp(r'<img[^>]+src="([^">]+)"').firstMatch(content);
+        if (match != null) {
+          images.add(BlogImage(title: title, imageUrl: match.group(1)!));
+        }
+      }
+
+      return images;
+    } on WallpapersException {
+      rethrow;
+    } catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        WallpapersException('تعذر معالجة بيانات الخلفيات: $error'),
+        stackTrace,
+      );
+    }
   }
 
   Future<Uint8List> downloadImageBytes(String url) async {
     final response = await _client.get(Uri.parse(url));
     if (response.statusCode != 200) {
-      throw Exception('فشل تحميل الصورة (${response.statusCode})');
+      throw WallpapersException('فشل تحميل الصورة (${response.statusCode})');
     }
     return response.bodyBytes;
   }

--- a/lib/features/wallpapers/presentation/pages/wallpapers_page.dart
+++ b/lib/features/wallpapers/presentation/pages/wallpapers_page.dart
@@ -27,8 +27,28 @@ class WallpapersPage extends StatelessWidget {
             }
 
             if (state.status == WallpapersStatus.failure) {
+              final message = state.errorMessage ?? '❌ حدث خطأ غير متوقع';
               return Center(
-                child: Text(state.errorMessage ?? '❌ حدث خطأ غير متوقع'),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 24),
+                      child: Text(
+                        message,
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(fontFamily: 'Tajawal'),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton.icon(
+                      onPressed: () =>
+                          context.read<WallpapersCubit>().loadWallpapers(),
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('إعادة المحاولة'),
+                    ),
+                  ],
+                ),
               );
             }
 

--- a/test/features/wallpapers/cubit/wallpapers_cubit_test.dart
+++ b/test/features/wallpapers/cubit/wallpapers_cubit_test.dart
@@ -40,8 +40,10 @@ void main() {
     await cubit.loadWallpapers();
   });
 
-  test('loadWallpapers emits failure when service throws', () async {
-    when(() => service.fetchWallpapers()).thenThrow(Exception('خطأ'));
+  test('loadWallpapers emits failure when service throws WallpapersException',
+      () async {
+    when(() => service.fetchWallpapers())
+        .thenThrow(const WallpapersException('خطأ'));
 
     expectLater(
       cubit.stream,
@@ -49,7 +51,24 @@ void main() {
         const WallpapersState(status: WallpapersStatus.loading),
         const WallpapersState(
           status: WallpapersStatus.failure,
-          errorMessage: 'Exception: خطأ',
+          errorMessage: 'خطأ',
+        ),
+      ]),
+    );
+
+    await cubit.loadWallpapers();
+  });
+
+  test('loadWallpapers emits generic message for unexpected errors', () async {
+    when(() => service.fetchWallpapers()).thenThrow(Exception('خطأ')); 
+
+    expectLater(
+      cubit.stream,
+      emitsInOrder([
+        const WallpapersState(status: WallpapersStatus.loading),
+        const WallpapersState(
+          status: WallpapersStatus.failure,
+          errorMessage: 'تعذر تحميل الخلفيات. الرجاء المحاولة لاحقاً.',
         ),
       ]),
     );

--- a/test/features/wallpapers/data/services/wallpapers_service_test.dart
+++ b/test/features/wallpapers/data/services/wallpapers_service_test.dart
@@ -48,7 +48,16 @@ void main() {
       (_) async => http.Response('Error', 500),
     );
 
-    expect(() => service.fetchWallpapers(), throwsA(isA<Exception>()));
+    expect(
+      () => service.fetchWallpapers(),
+      throwsA(
+        isA<WallpapersException>().having(
+          (e) => e.message,
+          'message',
+          contains('500'),
+        ),
+      ),
+    );
   });
 
   test('downloadImageBytes returns response bytes', () async {

--- a/test/features/wallpapers/presentation/pages/wallpapers_page_test.dart
+++ b/test/features/wallpapers/presentation/pages/wallpapers_page_test.dart
@@ -38,7 +38,8 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
 
-  testWidgets('shows error message when state is failure', (tester) async {
+  testWidgets('shows error message and retry button when state is failure',
+      (tester) async {
     when(() => cubit.state).thenReturn(
       const WallpapersState(
         status: WallpapersStatus.failure,
@@ -48,10 +49,18 @@ void main() {
     when(() => cubit.stream).thenAnswer(
       (_) => Stream<WallpapersState>.empty(),
     );
+    when(() => cubit.loadWallpapers()).thenAnswer((_) async {});
 
     await tester.pumpWidget(buildWidget());
 
     expect(find.text('خطأ'), findsOneWidget);
+    final retryFinder = find.widgetWithText(ElevatedButton, 'إعادة المحاولة');
+    expect(retryFinder, findsOneWidget);
+
+    await tester.tap(retryFinder);
+    await tester.pump();
+
+    verify(() => cubit.loadWallpapers()).called(1);
   });
 
   testWidgets('shows grid when images are available', (tester) async {


### PR DESCRIPTION
## Summary
- add a dedicated `WallpapersException` and ensure the service throws clear failures
- update the cubit to surface friendly error messages when loading wallpapers fails
- show an error message with a retry button in the wallpapers page and adjust tests

## Testing
- `flutter test` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c879152970832a8cf5ca4f93a3830b