### PR TITLE
Use theme text style for feature descriptions

### DIFF
--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -244,11 +244,12 @@ class _FeatureCard extends StatelessWidget {
               Expanded(
                 child: Text(
                   feature.description,
-                  style: const TextStyle(
-                    fontFamily: 'Tajawal',
-                    fontSize: 14,
-                    color: Colors.black54,
-                  ),
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontFamily: 'Tajawal',
+                      ) ??
+                      const TextStyle(
+                        fontFamily: 'Tajawal',
+                      ),
                 ),
               ),
               Align(


### PR DESCRIPTION
## Summary
- update feature card description text to use the theme bodyMedium style for dynamic colors

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9271eff40832a80e2a1298557c440