### PR TITLE
Adjust time picker theme colors

### DIFF
--- a/lib/features/adhkar_reminder/presentation/pages/adhkar_reminder_page.dart
+++ b/lib/features/adhkar_reminder/presentation/pages/adhkar_reminder_page.dart
@@ -94,15 +94,24 @@ class _AdhkarReminderView extends StatelessWidget {
       context: context,
       initialTime: initialTime,
       builder: (context, child) {
+        final theme = Theme.of(context);
+        final colorScheme = theme.colorScheme;
+        final isDark = theme.brightness == Brightness.dark;
+        final buttonTextColor = isDark ? colorScheme.secondary : colorScheme.primary;
+        final helpTextColor = isDark ? colorScheme.onSurface : colorScheme.onSurfaceVariant;
+
         return Theme(
-          data: Theme.of(context).copyWith(
+          data: theme.copyWith(
             textButtonTheme: TextButtonThemeData(
               style: TextButton.styleFrom(
-                foregroundColor: Colors.black,
+                foregroundColor: buttonTextColor,
               ),
             ),
-            timePickerTheme: const TimePickerThemeData(
-              helpTextStyle: TextStyle(color: Colors.black),
+            timePickerTheme: theme.timePickerTheme.copyWith(
+              helpTextStyle: theme.timePickerTheme.helpTextStyle?.copyWith(
+                    color: helpTextColor,
+                  ) ??
+                  TextStyle(color: helpTextColor),
             ),
           ),
           child: child!,


### PR DESCRIPTION
## Summary
- derive time picker text button and help text colors from the active theme instead of hard-coded black values
- ensure button and help text colors adapt to the current brightness for better contrast in light and dark modes

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca52c72fb0832aa87173b20f50d32a