### PR TITLE
Enable text selection in audio reader page

### DIFF
--- a/lib/features/audio/presentation/pages/audio_page.dart
+++ b/lib/features/audio/presentation/pages/audio_page.dart
@@ -2189,10 +2189,10 @@ class _TextReaderPageState extends State<TextReaderPage> {
           Expanded(
             child: SingleChildScrollView(
               padding: const EdgeInsets.all(16),
-              child: Text(
+              child: SelectableText(
                 widget.content,
                 style:
-                TextStyle(fontSize: _fontSize, fontFamily: 'Tajawal'),
+                    TextStyle(fontSize: _fontSize, fontFamily: 'Tajawal'),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- replace the static text widget in the audio reader with SelectableText to enable selection features while preserving styling

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca550b1a64832a8fecb07d6deb3299