### PR TITLE
Use color scheme driven action buttons

### DIFF
--- a/lib/features/audio/presentation/pages/audio_page.dart
+++ b/lib/features/audio/presentation/pages/audio_page.dart
@@ -1579,6 +1579,18 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
         : sleepTimerMinutes != null
             ? 'المؤقت متوقف - لن يتم إيقاف الصوت تلقائيًا (آخر مدة: ${sleepTimerMinutes} دقيقة).'
             : 'مؤقت النوم متوقف - لن يتم إيقاف الصوت تلقائيًا.';
+    final colorScheme = Theme.of(context).colorScheme;
+    final actionButtonStyle = ElevatedButton.styleFrom(
+      backgroundColor: colorScheme.primaryContainer,
+      foregroundColor: colorScheme.onPrimaryContainer,
+    );
+    final activeSleepTimerStyle = ElevatedButton.styleFrom(
+      backgroundColor: colorScheme.secondaryContainer,
+      foregroundColor: colorScheme.onSecondaryContainer,
+      side: BorderSide(
+        color: colorScheme.onSecondaryContainer.withOpacity(0.3),
+      ),
+    );
     return Directionality(
       textDirection: TextDirection.ltr,
       child: Container(
@@ -1677,10 +1689,7 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
                   },
                   icon: const Icon(Icons.menu_book),
                   label: const Text("قراءة"),
-                  style: ElevatedButton.styleFrom(
-                    foregroundColor: Theme.of(context).primaryColor,
-                    backgroundColor: Colors.white,
-                  ),
+                  style: actionButtonStyle,
                 ),
                 const SizedBox(width: 12), // مسافة بين الزرين
                 ElevatedButton.icon(
@@ -1689,13 +1698,8 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
                   label: Text(
                     isSleepTimerActive ? "مؤقت النوم (مفعل)" : "مؤقت النوم",
                   ),
-                  style: ElevatedButton.styleFrom(
-                    foregroundColor:
-                        isSleepTimerActive ? Colors.white : Theme.of(context).primaryColor,
-                    backgroundColor: isSleepTimerActive ? accentBlue : Colors.white,
-                    side:
-                        isSleepTimerActive ? const BorderSide(color: Colors.white70) : null,
-                  ),
+                  style:
+                      isSleepTimerActive ? activeSleepTimerStyle : actionButtonStyle,
                 ),
               ],
             ),

--- a/lib/features/wallpapers/presentation/pages/wallpapers_page.dart
+++ b/lib/features/wallpapers/presentation/pages/wallpapers_page.dart
@@ -236,6 +236,12 @@ class _FullImageViewState extends State<FullImageView> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final actionButtonStyle = ElevatedButton.styleFrom(
+      backgroundColor: colorScheme.primaryContainer,
+      foregroundColor: colorScheme.onPrimaryContainer,
+    );
+
     return Directionality(
       textDirection: TextDirection.rtl,
       child: Scaffold(
@@ -280,28 +286,19 @@ class _FullImageViewState extends State<FullImageView> {
                     onPressed: () => _handleDownload(context),
                     icon: const Icon(Icons.download),
                     label: const Text('تحميل'),
-                    style: ElevatedButton.styleFrom(
-                      foregroundColor: Theme.of(context).primaryColor,
-                      backgroundColor: Colors.white,
-                    ),
+                    style: actionButtonStyle,
                   ),
                   ElevatedButton.icon(
                     onPressed: () => _handleShare(context),
                     icon: const Icon(Icons.share),
                     label: const Text('مشاركة'),
-                    style: ElevatedButton.styleFrom(
-                      foregroundColor: Theme.of(context).primaryColor,
-                      backgroundColor: Colors.white,
-                    ),
+                    style: actionButtonStyle,
                   ),
                   ElevatedButton.icon(
                     onPressed: () => _showWallpaperOptions(context),
                     icon: const Icon(Icons.wallpaper),
                     label: const Text('تعيين خلفية'),
-                    style: ElevatedButton.styleFrom(
-                      foregroundColor: Theme.of(context).primaryColor,
-                      backgroundColor: Colors.white,
-                    ),
+                    style: actionButtonStyle,
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- apply a theme color-scheme based style to wallpaper detail action buttons
- reuse the same themed button styling for the audio player action bar

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca672cc194832aaa37b2291fab2c59