### PR TITLE
Align theme defaults with system preference

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -4,6 +4,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_in_app_messaging/firebase_in_app_messaging.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:just_audio_background/just_audio_background.dart';
@@ -72,9 +73,28 @@ class MyAppState extends State<MyApp> {
 
   Future<void> _loadTheme() async {
     await StorageService.init();
+    final storedTheme = StorageService.getTheme();
+
+    if (!mounted) {
+      return;
+    }
+
+    if (storedTheme != null) {
+      setState(() {
+        _isDarkMode = storedTheme;
+      });
+      return;
+    }
+
+    final platformBrightness =
+        SchedulerBinding.instance.platformDispatcher.platformBrightness;
+    final inferredDarkMode = platformBrightness == Brightness.dark;
+
     setState(() {
-      _isDarkMode = StorageService.getTheme();
+      _isDarkMode = inferredDarkMode;
     });
+
+    await StorageService.saveTheme(inferredDarkMode);
   }
 
   void toggleTheme() async {

--- a/lib/core/services/storage_service.dart
+++ b/lib/core/services/storage_service.dart
@@ -29,7 +29,11 @@ class StorageService {
     await _prefs?.setBool(AppConstants.isDarkModeKey, isDarkMode);
   }
 
-  static bool getTheme() {
-    return _prefs?.getBool(AppConstants.isDarkModeKey) ?? false;
+  static bool hasThemePreference() {
+    return _prefs?.containsKey(AppConstants.isDarkModeKey) ?? false;
+  }
+
+  static bool? getTheme() {
+    return _prefs?.getBool(AppConstants.isDarkModeKey);
   }
 }

--- a/test/app/theme_initialization_test.dart
+++ b/test/app/theme_initialization_test.dart
@@ -1,0 +1,36 @@
+import 'package:afasi/app/app.dart';
+import 'package:afasi/core/services/storage_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  for (final brightness in Brightness.values) {
+    testWidgets(
+        "initial theme matches system brightness when no preference is stored: "
+        "${brightness == Brightness.dark ? 'dark' : 'light'}",
+        (WidgetTester tester) async {
+      final binding = TestWidgetsFlutterBinding.ensureInitialized();
+      binding.platformDispatcher.platformBrightnessTestValue = brightness;
+      addTearDown(() {
+        binding.platformDispatcher.platformBrightnessTestValue = null;
+      });
+
+      await tester.pumpWidget(const MyApp());
+      await tester.pumpAndSettle();
+
+      final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+      final expectedThemeMode =
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light;
+
+      expect(materialApp.themeMode, expectedThemeMode);
+      expect(StorageService.getTheme(), brightness == Brightness.dark);
+    });
+  }
+}

--- a/test/core/services/storage_service_test.dart
+++ b/test/core/services/storage_service_test.dart
@@ -28,9 +28,14 @@ void main() {
   });
 
   test('persists and restores theme mode', () async {
-    expect(StorageService.getTheme(), isFalse);
+    expect(StorageService.getTheme(), isNull);
+    expect(StorageService.hasThemePreference(), isFalse);
 
     await StorageService.saveTheme(true);
+    expect(StorageService.hasThemePreference(), isTrue);
     expect(StorageService.getTheme(), isTrue);
+
+    await StorageService.saveTheme(false);
+    expect(StorageService.getTheme(), isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- expose whether a stored theme preference exists and stop forcing a default value
- default the application theme to the platform brightness when no preference is stored and persist that choice
- cover the new behavior with a widget test that verifies the initial theme matches the system setting

## Testing
- flutter test *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca71d0d758832a9577dba952d931e6