### PR TITLE
feat: customize adhkar reminder notification channels

### DIFF
--- a/lib/features/adhkar_reminder/data/services/adhkar_reminder_service.dart
+++ b/lib/features/adhkar_reminder/data/services/adhkar_reminder_service.dart
@@ -27,6 +27,9 @@ class AdhkarReminderService {
     required String title,
     required String body,
     required String sound,
+    required String channelId,
+    required String channelName,
+    String? channelDescription,
   }) async {
     await initialize();
     final tz.TZDateTime now = tz.TZDateTime.now(tz.local);
@@ -43,9 +46,9 @@ class AdhkarReminderService {
     }
 
     final androidDetails = AndroidNotificationDetails(
-      'adhkar_channel',
-      'أذكار',
-      channelDescription: 'تذكيرات أذكار الصباح والمساء',
+      channelId,
+      channelName,
+      channelDescription: channelDescription,
       importance: Importance.max,
       priority: Priority.high,
       sound: RawResourceAndroidNotificationSound(sound.replaceAll('.mp3', '')),
@@ -67,7 +70,16 @@ class AdhkarReminderService {
     );
   }
 
-  Future<void> cancelReminder(int id) async {
+  Future<void> cancelReminder(int id, {String? channelId}) async {
     await _plugin.cancel(id);
+    if (channelId != null) {
+      final androidPlugin = _plugin
+          .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+      try {
+        await androidPlugin?.deleteNotificationChannel(channelId);
+      } catch (_) {
+        // تجاهل في حال عدم توفر الدالة على النظام
+      }
+    }
   }
 }

--- a/lib/features/adhkar_reminder/presentation/cubit/adhkar_reminder_cubit.dart
+++ b/lib/features/adhkar_reminder/presentation/cubit/adhkar_reminder_cubit.dart
@@ -131,7 +131,7 @@ class AdhkarReminderCubit extends Cubit<AdhkarReminderState> {
         await _scheduleMorningReminder(updatedState.morningTime);
         emit(state.copyWith(statusMessage: 'تم تفعيل تذكير أذكار الصباح'));
       } else {
-        await _service.cancelReminder(100);
+        await _service.cancelReminder(100, channelId: 'adhkar_morning_channel');
         emit(state.copyWith(statusMessage: 'تم تعطيل تذكير أذكار الصباح'));
       }
     } catch (e) {
@@ -153,7 +153,7 @@ class AdhkarReminderCubit extends Cubit<AdhkarReminderState> {
         await _scheduleEveningReminder(updatedState.eveningTime);
         emit(state.copyWith(statusMessage: 'تم تفعيل تذكير أذكار المساء'));
       } else {
-        await _service.cancelReminder(101);
+        await _service.cancelReminder(101, channelId: 'adhkar_evening_channel');
         emit(state.copyWith(statusMessage: 'تم تعطيل تذكير أذكار المساء'));
       }
     } catch (e) {
@@ -228,6 +228,9 @@ class AdhkarReminderCubit extends Cubit<AdhkarReminderState> {
       title: 'أذكار الصباح',
       body: 'حان وقت أذكار الصباح',
       sound: 'mishary1.mp3',
+      channelId: 'adhkar_morning_channel',
+      channelName: 'قناة أذكار الصباح',
+      channelDescription: 'تنبيهات يومية لأذكار الصباح',
     );
   }
 
@@ -238,6 +241,9 @@ class AdhkarReminderCubit extends Cubit<AdhkarReminderState> {
       title: 'أذكار المساء',
       body: 'حان وقت أذكار المساء',
       sound: 'mishary2.mp3',
+      channelId: 'adhkar_evening_channel',
+      channelName: 'قناة أذكار المساء',
+      channelDescription: 'تنبيهات يومية لأذكار المساء',
     );
   }
 

--- a/test/features/adhkar_reminder/presentation/cubit/adhkar_reminder_cubit_test.dart
+++ b/test/features/adhkar_reminder/presentation/cubit/adhkar_reminder_cubit_test.dart
@@ -39,8 +39,14 @@ void main() {
           title: any(named: 'title'),
           body: any(named: 'body'),
           sound: any(named: 'sound'),
+          channelId: any(named: 'channelId'),
+          channelName: any(named: 'channelName'),
+          channelDescription: any(named: 'channelDescription'),
         )).thenAnswer((_) async {});
-    when(() => service.cancelReminder(any())).thenAnswer((_) async {});
+    when(() => service.cancelReminder(
+          any(),
+          channelId: any(named: 'channelId'),
+        )).thenAnswer((_) async {});
 
     cubit = TestAdhkarReminderCubit(service: service);
     emittedStates = [];
@@ -75,6 +81,9 @@ void main() {
           title: any(named: 'title'),
           body: any(named: 'body'),
           sound: any(named: 'sound'),
+          channelId: 'adhkar_morning_channel',
+          channelName: 'قناة أذكار الصباح',
+          channelDescription: 'تنبيهات يومية لأذكار الصباح',
         )).called(1);
   });
 
@@ -99,7 +108,10 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getBool('morningEnabled'), isFalse);
 
-    verify(() => service.cancelReminder(100)).called(1);
+    verify(() => service.cancelReminder(
+          100,
+          channelId: 'adhkar_morning_channel',
+        )).called(1);
   });
 
   test('toggleEvening enables reminder and schedules notification', () async {
@@ -125,6 +137,9 @@ void main() {
           title: any(named: 'title'),
           body: any(named: 'body'),
           sound: any(named: 'sound'),
+          channelId: 'adhkar_evening_channel',
+          channelName: 'قناة أذكار المساء',
+          channelDescription: 'تنبيهات يومية لأذكار المساء',
         )).called(1);
   });
 
@@ -156,6 +171,9 @@ void main() {
           title: any(named: 'title'),
           body: any(named: 'body'),
           sound: any(named: 'sound'),
+          channelId: 'adhkar_morning_channel',
+          channelName: 'قناة أذكار الصباح',
+          channelDescription: 'تنبيهات يومية لأذكار الصباح',
         )).called(1);
   });
 }


### PR DESCRIPTION
## Summary
- allow scheduling reminders with configurable Android notification channels per sound
- route morning and evening reminders to distinct channels and clean them up when toggled off
- update reminder cubit tests to cover channel identifiers and cleanup behavior

## Testing
- `flutter test test/features/adhkar_reminder/presentation/cubit/adhkar_reminder_cubit_test.dart` *(fails: flutter not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8e045644832a95e5541c7529c4fa