### PR TITLE
Adjust prayer notifications to reschedule past times

### DIFF
--- a/lib/features/prayer_times/data/services/prayer_notification_service.dart
+++ b/lib/features/prayer_times/data/services/prayer_notification_service.dart
@@ -38,10 +38,6 @@ class PrayerNotificationService {
   }
 
   Future<void> schedulePrayerNotification(String prayerName, DateTime time) async {
-    if (!time.isAfter(DateTime.now())) {
-      return;
-    }
-
     const AndroidNotificationDetails androidDetails = AndroidNotificationDetails(
       'prayer_channel',
       'Prayer Times',
@@ -60,7 +56,12 @@ class PrayerNotificationService {
       iOS: iosDetails,
     );
 
-    final tz.TZDateTime scheduledDate = tz.TZDateTime.from(time, tz.local);
+    final tz.TZDateTime now = tz.TZDateTime.now(tz.local);
+    tz.TZDateTime scheduledDate = tz.TZDateTime.from(time, tz.local);
+
+    while (!scheduledDate.isAfter(now)) {
+      scheduledDate = scheduledDate.add(const Duration(days: 1));
+    }
 
     await _plugin.zonedSchedule(
       prayerName.hashCode,
@@ -75,6 +76,7 @@ class PrayerNotificationService {
   }
 
   Future<void> cancelAll() async {
+    await initialize();
     await _plugin.cancelAll();
   }
 }

--- a/lib/features/prayer_times/presentation/cubit/prayer_times_cubit.dart
+++ b/lib/features/prayer_times/presentation/cubit/prayer_times_cubit.dart
@@ -78,7 +78,7 @@ class PrayerTimesCubit extends Cubit<PrayerTimesState> {
 
       if (notificationsEnabled) {
         try {
-          await _notificationService.schedulePrayerNotifications(times);
+          await _rescheduleNotifications(times);
         } catch (e) {
           emit(state.copyWith(errorMessage: e.toString()));
         }
@@ -104,7 +104,7 @@ class PrayerTimesCubit extends Cubit<PrayerTimesState> {
 
       if (state.notificationsEnabled) {
         try {
-          await _notificationService.schedulePrayerNotifications(times);
+          await _rescheduleNotifications(times);
         } catch (e) {
           emit(state.copyWith(errorMessage: e.toString()));
         }
@@ -137,7 +137,7 @@ class PrayerTimesCubit extends Cubit<PrayerTimesState> {
       ));
     } else {
       try {
-        await _notificationService.schedulePrayerNotifications(times);
+        await _rescheduleNotifications(times);
         await prefs.setBool('notificationsScheduled', true);
         emit(state.copyWith(
           notificationsEnabled: true,
@@ -158,5 +158,10 @@ class PrayerTimesCubit extends Cubit<PrayerTimesState> {
 
   Future<SharedPreferences> _ensurePrefs() async {
     return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  Future<void> _rescheduleNotifications(PrayerTimes times) async {
+    await _notificationService.cancelAll();
+    await _notificationService.schedulePrayerNotifications(times);
   }
 }

--- a/test/features/prayer_times/presentation/cubit/prayer_times_cubit_test.dart
+++ b/test/features/prayer_times/presentation/cubit/prayer_times_cubit_test.dart
@@ -86,6 +86,7 @@ void main() {
 
     final loadedState = emittedStates.last;
     expect(loadedState.notificationsEnabled, isTrue);
+    verify(() => notificationService.cancelAll()).called(1);
     verify(() =>
             notificationService.schedulePrayerNotifications(testPrayerTimes))
         .called(1);
@@ -105,6 +106,7 @@ void main() {
 
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getBool('notificationsScheduled'), isTrue);
+    verify(() => notificationService.cancelAll()).called(1);
     verify(() =>
             notificationService.schedulePrayerNotifications(testPrayerTimes))
         .called(1);
@@ -129,7 +131,7 @@ void main() {
 
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getBool('notificationsScheduled'), isFalse);
-    verify(() => notificationService.cancelAll()).called(1);
+    verify(() => notificationService.cancelAll()).called(2);
   });
 
   test('toggleNotifications emits error when prayer times are missing',
@@ -178,6 +180,7 @@ void main() {
     expect(refreshedState.errorMessage, isNull);
 
     verify(() => repository.fetchPrayerTimes()).called(2);
+    verify(() => notificationService.cancelAll()).called(2);
     verify(() =>
             notificationService.schedulePrayerNotifications(updatedTimes))
         .called(1);


### PR DESCRIPTION
## Summary
- reschedule prayer notifications for the next day when the computed time is already in the past
- centralize notification re-scheduling so existing bookings are cleared before new ones are scheduled
- extend cubit tests to cover the new cancellation behaviour

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8eb670d0832a9e54635ddd4bacf9