### PR TITLE
Request notification permission before scheduling prayer alerts

### DIFF
--- a/lib/features/prayer_times/data/services/prayer_notification_service.dart
+++ b/lib/features/prayer_times/data/services/prayer_notification_service.dart
@@ -27,6 +27,20 @@ class PrayerNotificationService {
     _initialized = true;
   }
 
+  Future<bool> requestNotificationPermission() async {
+    await initialize();
+    final androidImplementation = _plugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+
+    if (androidImplementation != null) {
+      final granted = await androidImplementation.requestPermission();
+      return granted ?? true;
+    }
+
+    return true;
+  }
+
   Future<void> schedulePrayerNotifications(PrayerTimes prayerTimes) async {
     await initialize();
     await schedulePrayerNotification('الفجر', prayerTimes.fajr);


### PR DESCRIPTION
## Summary
- request notification permission on Android before rescheduling prayer alerts
- surface a clear error and disable stored preference when permission is denied
- extend cubit tests to cover the permission request workflow

## Testing
- Not run (flutter command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca93733dec832aa2b29776a86eb864