### PR TITLE
Implement lazy YouTube audio source loading

### DIFF
--- a/lib/core/services/audio_service.dart
+++ b/lib/core/services/audio_service.dart
@@ -12,13 +12,13 @@ class AudioService {
   AudioService({AudioPlayer? audioPlayer}) : _audioPlayer = audioPlayer ?? AudioPlayer();
 
   final AudioPlayer _audioPlayer;
-  final Map<String, String> _youtubeCache = {};
+  final Map<String, YoutubeAudioCacheEntry> _youtubeCache = {};
 
   StreamSubscription<ProcessingState>? _processingStateSubscription;
   StreamSubscription<bool>? _playingStreamSubscription;
 
   AudioPlayer get audioPlayer => _audioPlayer;
-  Map<String, String> get youtubeCache => _youtubeCache;
+  Map<String, YoutubeAudioCacheEntry> get youtubeCache => _youtubeCache;
 
   void initialize({
     void Function(ProcessingState state)? onProcessingStateChanged,
@@ -33,62 +33,12 @@ class AudioService {
   }
 
   Future<void> setAudioSource(Supplication supplication) async {
-    String source = supplication.audioUrl;
-    
-    if (supplication.isLocalAudio) {
-      await _audioPlayer.setAudioSource(
-        AudioSource.asset(
-          source,
-          tag: MediaItem(
-            id: source,
-            title: supplication.title,
-            album: 'Audio',
-          ),
-        ),
-      );
-      return;
-    }
-
-    // Check if downloaded
-    final Directory dir = await getApplicationSupportDirectory();
-    final String filePath = '${dir.path}/${supplication.title}.mp3';
-    if (await File(filePath).exists()) {
-      await _audioPlayer.setAudioSource(
-        AudioSource.file(
-          filePath,
-          tag: MediaItem(
-            id: filePath,
-            title: supplication.title,
-            album: 'Audio',
-          ),
-        ),
-      );
-      return;
-    }
-
-    // Handle YouTube URLs
-    if (source.contains("youtube.com") || source.contains("youtu.be")) {
-      final String? videoId = _extractYoutubeVideoId(source);
-      if (videoId != null) {
-        if (_youtubeCache.containsKey(videoId)) {
-          source = _youtubeCache[videoId]!;
-        } else {
-          source = await _extractYoutubeAudioUrl(videoId);
-          _youtubeCache[videoId] = source;
-        }
-      }
-    }
-
-    await _audioPlayer.setAudioSource(
-      AudioSource.uri(
-        Uri.parse(source),
-        tag: MediaItem(
-          id: source,
-          title: supplication.title,
-          album: 'Audio',
-        ),
-      ),
+    final AudioSource audioSource = await _buildAudioSourceForSupplication(
+      supplication,
+      album: 'Audio',
     );
+
+    await _audioPlayer.setAudioSource(audioSource);
   }
 
   Future<void> setPlaylist({
@@ -123,14 +73,17 @@ class AudioService {
   }) async {
     String source = supplication.audioUrl;
 
+    final String resolvedAlbum = album ?? 'Audio';
+    final MediaItem mediaItem = MediaItem(
+      id: source,
+      title: supplication.title,
+      album: resolvedAlbum,
+    );
+
     if (supplication.isLocalAudio) {
       return AudioSource.asset(
         source,
-        tag: MediaItem(
-          id: source,
-          title: supplication.title,
-          album: album ?? 'Audio',
-        ),
+        tag: mediaItem,
       );
     }
 
@@ -142,7 +95,7 @@ class AudioService {
         tag: MediaItem(
           id: filePath,
           title: supplication.title,
-          album: album ?? 'Audio',
+          album: resolvedAlbum,
         ),
       );
     }
@@ -150,31 +103,39 @@ class AudioService {
     if (source.contains('youtube.com') || source.contains('youtu.be')) {
       final String? videoId = _extractYoutubeVideoId(source);
       if (videoId != null) {
-        if (_youtubeCache.containsKey(videoId)) {
-          source = _youtubeCache[videoId]!;
-        } else {
-          source = await _extractYoutubeAudioUrl(videoId);
-          _youtubeCache[videoId] = source;
-        }
+        final YoutubeAudioCacheEntry? cachedEntry = _youtubeCache[videoId];
+        return LazyYoutubeAudioSource(
+          videoId: videoId,
+          initialEntry: cachedEntry,
+          cache: _youtubeCache,
+          extractor: _extractYoutubeAudioUrl,
+          mediaItem: MediaItem(
+            id: videoId,
+            title: supplication.title,
+            album: resolvedAlbum,
+          ),
+        );
       }
     }
 
     return AudioSource.uri(
       Uri.parse(source),
-      tag: MediaItem(
-        id: source,
-        title: supplication.title,
-        album: album ?? 'Audio',
-      ),
+      tag: mediaItem,
     );
   }
 
-  Future<String> _extractYoutubeAudioUrl(String videoId) async {
+  Future<YoutubeAudioCacheEntry> _extractYoutubeAudioUrl(String videoId) async {
     final yt = YoutubeExplode();
     try {
       final manifest = await yt.videos.streamsClient.getManifest(videoId);
       final audioStreamInfo = manifest.audioOnly.withHighestBitrate();
-      return audioStreamInfo.url.toString();
+      final String? mimeType = audioStreamInfo.codec.mimeType;
+      final int? totalBytes = audioStreamInfo.size.totalBytes;
+      return YoutubeAudioCacheEntry(
+        url: audioStreamInfo.url.toString(),
+        mimeType: mimeType,
+        contentLength: totalBytes,
+      );
     } finally {
       yt.close();
     }
@@ -198,5 +159,112 @@ class AudioService {
     _processingStateSubscription?.cancel();
     _playingStreamSubscription?.cancel();
     _audioPlayer.dispose();
+  }
+}
+
+class YoutubeAudioCacheEntry {
+  YoutubeAudioCacheEntry({
+    required this.url,
+    this.mimeType,
+    this.contentLength,
+  });
+
+  final String url;
+  final String? mimeType;
+  final int? contentLength;
+}
+
+class LazyYoutubeAudioSource extends StreamAudioSource {
+  LazyYoutubeAudioSource({
+    required this.videoId,
+    required this.cache,
+    required this.extractor,
+    required MediaItem mediaItem,
+    YoutubeAudioCacheEntry? initialEntry,
+  })  : _cachedEntry = initialEntry,
+        super(tag: mediaItem);
+
+  static final HttpClient _httpClient = HttpClient();
+
+  final String videoId;
+  final Map<String, YoutubeAudioCacheEntry> cache;
+  final Future<YoutubeAudioCacheEntry> Function(String videoId) extractor;
+
+  YoutubeAudioCacheEntry? _cachedEntry;
+  Future<YoutubeAudioCacheEntry>? _pendingExtraction;
+
+  @override
+  Future<StreamAudioResponse> request([int? start, int? end]) async {
+    final YoutubeAudioCacheEntry entry = await _ensureEntry();
+    final Uri uri = Uri.parse(entry.url);
+
+    final HttpClientRequest request = await _httpClient.getUrl(uri);
+    _applyRangeHeaders(request, start: start, end: end);
+
+    final HttpClientResponse response = await request.close();
+    final int? sourceLength = entry.contentLength ??
+        _parseContentRange(response.headers.value(HttpHeaders.contentRangeHeader));
+    final int contentLength = response.contentLength;
+
+    return StreamAudioResponse(
+      sourceLength: sourceLength ?? (contentLength >= 0 ? contentLength : null),
+      contentLength: contentLength >= 0 ? contentLength : null,
+      offset: start ?? 0,
+      stream: response,
+      contentType:
+          entry.mimeType ?? response.headers.contentType?.mimeType ?? 'audio/mp4',
+    );
+  }
+
+  Future<YoutubeAudioCacheEntry> _ensureEntry() async {
+    if (_cachedEntry != null) {
+      return _cachedEntry!;
+    }
+
+    final YoutubeAudioCacheEntry? cached = cache[videoId];
+    if (cached != null) {
+      _cachedEntry = cached;
+      return cached;
+    }
+
+    _pendingExtraction ??= extractor(videoId);
+    final YoutubeAudioCacheEntry resolved = await _pendingExtraction!;
+    cache[videoId] = resolved;
+    _cachedEntry = resolved;
+    _pendingExtraction = null;
+    return resolved;
+  }
+
+  void _applyRangeHeaders(
+    HttpClientRequest request, {
+    int? start,
+    int? end,
+  }) {
+    if (start == null && end == null) {
+      return;
+    }
+
+    if (start == null && end != null) {
+      request.headers.set(HttpHeaders.rangeHeader, 'bytes=-${end - 1}');
+      return;
+    }
+
+    final String endPart = end != null ? '${end - 1}' : '';
+    request.headers.set(HttpHeaders.rangeHeader, 'bytes=$start-$endPart');
+  }
+
+  int? _parseContentRange(String? headerValue) {
+    if (headerValue == null) {
+      return null;
+    }
+    final RegExpMatch? match = RegExp(r'/(\d+|\*)$').firstMatch(headerValue.trim());
+    if (match == null) {
+      return null;
+    }
+    final String value = match.group(1)!;
+    if (value == '*') {
+      return null;
+    }
+    return int.tryParse(value);
   }
 }

--- a/lib/features/audio/presentation/pages/audio_page.dart
+++ b/lib/features/audio/presentation/pages/audio_page.dart
@@ -1076,14 +1076,6 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
       }
     }
 
-    bool showLoading = false;
-    if (requiresNetwork &&
-        (supp.audioUrl.contains('youtube.com') ||
-            supp.audioUrl.contains('youtu.be'))) {
-      showLoading = true;
-      showLoadingDialog("جاري تجهيز الصوت ...");
-    }
-
     try {
       // Build playlist based on current filtered list to enable next/prev in notification
       final int initialIndex = filteredSupplications
@@ -1098,10 +1090,6 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
       print("Error playing audio: $e");
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('خطأ في تشغيل الصوت.')));
-    } finally {
-      if (showLoading && mounted && Navigator.canPop(context)) {
-        Navigator.pop(context);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add a custom `LazyYoutubeAudioSource` that resolves YouTube audio streams on demand and caches the results inside `AudioService`
- reuse the lazy builder for individual sources and playlists so setup no longer blocks on resolving every YouTube link
- simplify `AudioPage.playAudio` by removing the manual loading dialog now that playback starts without prefetching all URLs

## Testing
- not run (Flutter tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68cac492c014832a9f1c5105840a1a99