### PR TITLE
Handle YouTube audio cache expiry and retry playback

### DIFF
--- a/test/core/services/audio_service_test.dart
+++ b/test/core/services/audio_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:audio_service/audio_service.dart' show MediaItem;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:just_audio/just_audio.dart';
@@ -13,11 +14,14 @@ void main() {
     final mockPlayer = MockAudioPlayer();
     final processingController = StreamController<ProcessingState>.broadcast();
     final playingController = StreamController<bool>.broadcast();
+    final playbackController = StreamController<PlaybackEvent>.broadcast();
 
     when(() => mockPlayer.processingStateStream)
         .thenAnswer((_) => processingController.stream);
     when(() => mockPlayer.playingStream)
         .thenAnswer((_) => playingController.stream);
+    when(() => mockPlayer.playbackEventStream)
+        .thenAnswer((_) => playbackController.stream);
     when(() => mockPlayer.dispose()).thenAnswer((_) async {});
 
     final service = AudioService(audioPlayer: mockPlayer);
@@ -41,8 +45,45 @@ void main() {
 
     expect(processingController.hasListener, isFalse);
     expect(playingController.hasListener, isFalse);
+    expect(playbackController.hasListener, isFalse);
 
     await processingController.close();
     await playingController.close();
+    await playbackController.close();
+  });
+
+  test('refreshes YouTube cache entry when expired', () async {
+    final cache = <String, YoutubeAudioCacheEntry>{};
+    int extractionCount = 0;
+
+    Future<YoutubeAudioCacheEntry> extractor(String videoId) async {
+      extractionCount++;
+      return YoutubeAudioCacheEntry(
+        url: 'https://example.com/audio$extractionCount',
+        fetchedAt: DateTime.now(),
+        validity: const Duration(milliseconds: 10),
+      );
+    }
+
+    final source = LazyYoutubeAudioSource(
+      videoId: 'abc123',
+      cache: cache,
+      extractor: extractor,
+      mediaItem: const MediaItem(id: 'abc123', title: 'Test', album: 'Album'),
+    );
+
+    final YoutubeAudioCacheEntry initial = await source.debugEnsureEntry();
+    expect(initial.url, 'https://example.com/audio1');
+    expect(extractionCount, 1);
+
+    final YoutubeAudioCacheEntry expired = initial.copyWith(
+      fetchedAt: initial.fetchedAt.subtract(const Duration(hours: 2)),
+    );
+    source.debugCacheEntry(expired);
+
+    final YoutubeAudioCacheEntry refreshed = await source.debugEnsureEntry();
+    expect(refreshed.url, 'https://example.com/audio2');
+    expect(extractionCount, 2);
+    expect(cache['abc123']?.url, refreshed.url);
   });
 }


### PR DESCRIPTION
## Summary
- record fetch timestamps and validity for cached YouTube audio entries and validate them before reuse
- refresh expired or failing YouTube URLs automatically, including playback error retry handling
- cover cache refresh behaviour with a regression test for reusing a clip after a long wait

## Testing
- flutter test *(fails: `flutter` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac7791e70832a865afbf8e0a2de85