### PR TITLE
Keep sleep timer active across audio page

### DIFF
--- a/lib/features/audio/presentation/pages/audio_page.dart
+++ b/lib/features/audio/presentation/pages/audio_page.dart
@@ -919,7 +919,6 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
     _interstitialAd?.dispose();
     _rewardedAd?.dispose();
     _searchController.dispose();
-    _sleepTimerService.dispose();
     super.dispose();
   }
 
@@ -1616,9 +1615,7 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
                 IconButton(
                   icon: const Icon(Icons.close, color: Colors.white),
                   onPressed: () async {
-                    if (_sleepTimerService.isActive) {
-                      _sleepTimerService.cancelTimer();
-                    }
+                    _sleepTimerService.cancelTimer();
 
                     if (audioService.audioPlayer.playing ||
                         audioService.audioPlayer.processingState !=


### PR DESCRIPTION
## Summary
- keep the shared sleep timer service alive when the audio page is disposed so timers survive navigation
- explicitly cancel the sleep timer when closing the in-page player to preserve manual stop behaviour

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf235771c832aaa74706ec41f4639