### PR TITLE
Handle interstitial reuse lifecycle

### DIFF
--- a/lib/features/audio/presentation/pages/audio_page.dart
+++ b/lib/features/audio/presentation/pages/audio_page.dart
@@ -998,7 +998,21 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
       adUnitId: AppConstants.interstitialAdUnitId,
       request: const AdRequest(),
       adLoadCallback: InterstitialAdLoadCallback(
-        onAdLoaded: (ad) => _interstitialAd = ad,
+        onAdLoaded: (ad) {
+          ad.fullScreenContentCallback = FullScreenContentCallback(
+            onAdDismissedFullScreenContent: (ad) {
+              ad.dispose();
+              _interstitialAd = null;
+              loadInterstitialAd();
+            },
+            onAdFailedToShowFullScreenContent: (ad, error) {
+              ad.dispose();
+              _interstitialAd = null;
+              loadInterstitialAd();
+            },
+          );
+          _interstitialAd = ad;
+        },
         onAdFailedToLoad: (error) => _interstitialAd = null,
       ),
     );
@@ -1348,6 +1362,7 @@ class _AudioPageState extends State<AudioPage> with WidgetsBindingObserver {
     // مثال: عرض إعلان بعد كل 5 تشغيلات
     if (_usageCounter >= 5 && _interstitialAd != null) {
       _interstitialAd!.show();
+      _interstitialAd = null;
       _usageCounter = 0;
       loadInterstitialAd();
     }


### PR DESCRIPTION
## Summary
- reset the interstitial reference immediately after showing it and reload a fresh ad
- attach full-screen lifecycle callbacks so the ad reloads after being closed or failing to show

## Testing
- `flutter analyze` *(fails: `flutter` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf72ce454832aa17fb842692b5eae