### PR TITLE
Add native ad factory for list tile layout on iOS

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,11 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
-		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
+                1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+                331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
+                3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+                74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+                A1B2C3D4E5F6070890ABCDE0 /* ListTileNativeAdFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6070890ABCDEF /* ListTileNativeAdFactory.swift */; };
+                97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -41,13 +42,14 @@
 
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
-		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
-		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
-		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+                1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+                331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
+                331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+                3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+                74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
+                74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+                A1B2C3D4E5F6070890ABCDEF /* ListTileNativeAdFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTileNativeAdFactory.swift; sourceTree = "<group>"; };
+                7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -114,11 +116,12 @@
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
-				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
-				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
-				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
-			);
-			path = Runner;
+                                1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
+                                74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+                                A1B2C3D4E5F6070890ABCDEF /* ListTileNativeAdFactory.swift */,
+                                74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+                        );
+                        path = Runner;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -264,13 +267,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		97C146EA1CF9000F007C117D /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
-				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
-			);
+                97C146EA1CF9000F007C117D /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                A1B2C3D4E5F6070890ABCDE0 /* ListTileNativeAdFactory.swift in Sources */,
+                                74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+                                1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import google_mobile_ads
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -7,7 +8,13 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    FLTGoogleMobileAdsPlugin.registerNativeAdFactory(self, "listTile", ListTileNativeAdFactory())
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func applicationWillTerminate(_ application: UIApplication) {
+    FLTGoogleMobileAdsPlugin.unregisterNativeAdFactory(self, "listTile")
+    super.applicationWillTerminate(application)
   }
 }

--- a/ios/Runner/ListTileNativeAdFactory.swift
+++ b/ios/Runner/ListTileNativeAdFactory.swift
@@ -1,0 +1,128 @@
+import Foundation
+import GoogleMobileAds
+import UIKit
+
+/// Factory that builds a list-tile styled native ad view matching the Flutter layout expectations.
+final class ListTileNativeAdFactory: NSObject, GADNativeAdFactory {
+  func createNativeAd(
+    _ nativeAd: GADNativeAd,
+    customOptions: [AnyHashable: Any]? = nil
+  ) -> GADNativeAdView? {
+    let adView = GADNativeAdView(frame: .zero)
+    adView.translatesAutoresizingMaskIntoConstraints = false
+    adView.backgroundColor = UIColor.secondarySystemBackground
+    adView.layer.cornerRadius = 12
+    adView.clipsToBounds = true
+
+    let contentLayoutGuide = adView.layoutMarginsGuide
+    adView.layoutMargins = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+
+    // Icon view set to a fixed square size to resemble a list tile thumbnail.
+    let iconImageView = UIImageView(frame: .zero)
+    iconImageView.translatesAutoresizingMaskIntoConstraints = false
+    iconImageView.contentMode = .scaleAspectFill
+    iconImageView.layer.cornerRadius = 8
+    iconImageView.clipsToBounds = true
+    iconImageView.setContentHuggingPriority(.required, for: .horizontal)
+    iconImageView.setContentCompressionResistancePriority(.required, for: .horizontal)
+    NSLayoutConstraint.activate([
+      iconImageView.widthAnchor.constraint(equalToConstant: 60),
+      iconImageView.heightAnchor.constraint(equalTo: iconImageView.widthAnchor)
+    ])
+
+    // Headline label uses a semibold font similar to Flutter's ListTile.
+    let headlineLabel = UILabel()
+    headlineLabel.translatesAutoresizingMaskIntoConstraints = false
+    headlineLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+    headlineLabel.numberOfLines = 2
+
+    // Advertiser label shown beneath the headline if available.
+    let advertiserLabel = UILabel()
+    advertiserLabel.translatesAutoresizingMaskIntoConstraints = false
+    advertiserLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+    advertiserLabel.textColor = .secondaryLabel
+    advertiserLabel.numberOfLines = 1
+
+    // Primary call-to-action button aligned to the trailing edge.
+    let callToActionButton = UIButton(type: .system)
+    callToActionButton.translatesAutoresizingMaskIntoConstraints = false
+    callToActionButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
+    callToActionButton.backgroundColor = UIColor.systemBlue
+    callToActionButton.tintColor = .white
+    callToActionButton.layer.cornerRadius = 8
+    callToActionButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+    callToActionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+    callToActionButton.setContentHuggingPriority(.required, for: .horizontal)
+    callToActionButton.isUserInteractionEnabled = false
+
+    let topTextStack = UIStackView(arrangedSubviews: [headlineLabel, advertiserLabel])
+    topTextStack.translatesAutoresizingMaskIntoConstraints = false
+    topTextStack.axis = .vertical
+    topTextStack.spacing = 2
+
+    let topRowStack = UIStackView(arrangedSubviews: [iconImageView, topTextStack, callToActionButton])
+    topRowStack.translatesAutoresizingMaskIntoConstraints = false
+    topRowStack.axis = .horizontal
+    topRowStack.alignment = .center
+    topRowStack.spacing = 12
+
+    // Body label is shown beneath the top row to provide additional ad details.
+    let bodyLabel = UILabel()
+    bodyLabel.translatesAutoresizingMaskIntoConstraints = false
+    bodyLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+    bodyLabel.textColor = .secondaryLabel
+    bodyLabel.numberOfLines = 0
+
+    let contentStack = UIStackView(arrangedSubviews: [topRowStack, bodyLabel])
+    contentStack.translatesAutoresizingMaskIntoConstraints = false
+    contentStack.axis = .vertical
+    contentStack.spacing = 8
+
+    adView.addSubview(contentStack)
+    NSLayoutConstraint.activate([
+      contentStack.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor),
+      contentStack.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor),
+      contentStack.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor),
+      contentStack.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor)
+    ])
+
+    adView.headlineView = headlineLabel
+    adView.bodyView = bodyLabel
+    adView.iconView = iconImageView
+    adView.callToActionView = callToActionButton
+    adView.advertiserView = advertiserLabel
+
+    headlineLabel.text = nativeAd.headline
+    adView.nativeAd = nativeAd
+
+    if let body = nativeAd.body, !body.isEmpty {
+      bodyLabel.text = body
+      bodyLabel.isHidden = false
+    } else {
+      bodyLabel.isHidden = true
+    }
+
+    if let advertiser = nativeAd.advertiser, !advertiser.isEmpty {
+      advertiserLabel.text = advertiser
+      advertiserLabel.isHidden = false
+    } else {
+      advertiserLabel.isHidden = true
+    }
+
+    if let callToAction = nativeAd.callToAction, !callToAction.isEmpty {
+      callToActionButton.setTitle(callToAction, for: .normal)
+      callToActionButton.isHidden = false
+    } else {
+      callToActionButton.isHidden = true
+    }
+
+    if let icon = nativeAd.icon?.image {
+      iconImageView.image = icon
+      iconImageView.isHidden = false
+    } else {
+      iconImageView.isHidden = true
+    }
+
+    return adView
+  }
+}


### PR DESCRIPTION
## Summary
- add a native ad factory that programmatically builds a list-tile styled `GADNativeAdView`
- register and unregister the list tile factory in the iOS app delegate lifecycle
- link the new Swift source file into the Runner target so it builds with the app

## Testing
- not run (iOS tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc03ea7a04832ab7b226ae119d964b