### PR TITLE
Set timezone for notification services

### DIFF
--- a/lib/features/adhkar_reminder/data/services/adhkar_reminder_service.dart
+++ b/lib/features/adhkar_reminder/data/services/adhkar_reminder_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
@@ -12,6 +13,12 @@ class AdhkarReminderService {
   Future<void> initialize() async {
     if (_initialized) return;
     tz.initializeTimeZones();
+    try {
+      final String timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
+      tz.setLocalLocation(tz.getLocation(timeZoneName));
+    } catch (_) {
+      tz.setLocalLocation(tz.getLocation('UTC'));
+    }
     const AndroidInitializationSettings androidSettings =
         AndroidInitializationSettings('@mipmap/ic_launcher');
     const InitializationSettings settings = InitializationSettings(

--- a/lib/features/prayer_times/data/services/prayer_notification_service.dart
+++ b/lib/features/prayer_times/data/services/prayer_notification_service.dart
@@ -1,5 +1,6 @@
 import 'package:adhan/adhan.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
@@ -12,6 +13,12 @@ class PrayerNotificationService {
   Future<void> initialize() async {
     if (_initialized) return;
     tz.initializeTimeZones();
+    try {
+      final String timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
+      tz.setLocalLocation(tz.getLocation(timeZoneName));
+    } catch (_) {
+      tz.setLocalLocation(tz.getLocation('UTC'));
+    }
     const AndroidInitializationSettings androidSettings =
         AndroidInitializationSettings('@mipmap/ic_launcher');
     const DarwinInitializationSettings iosSettings = DarwinInitializationSettings(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   http: ^1.3.0
   youtube_explode_dart: ^2.3.6
   flutter_local_notifications: ^18.0.1
+  flutter_native_timezone: ^2.0.0
   shared_preferences: ^2.5.1
   just_audio: ^0.9.45
   just_audio_background: ^0.0.1-beta.17


### PR DESCRIPTION
## Summary
- configure the adhkar reminder service to read the device time zone and set the timezone package accordingly
- apply the same local time zone configuration to the prayer notification service so schedules use the right location
- add the flutter_native_timezone dependency for time zone resolution

## Testing
- `flutter pub get` *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2f3dd9cc832a81a21e0c0b908c5f