### PR TITLE
Replace flutter_native_timezone with flutter_timezone

### DIFF
--- a/lib/features/adhkar_reminder/data/services/adhkar_reminder_service.dart
+++ b/lib/features/adhkar_reminder/data/services/adhkar_reminder_service.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
@@ -14,7 +14,7 @@ class AdhkarReminderService {
     if (_initialized) return;
     tz.initializeTimeZones();
     try {
-      final String timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
+      final String timeZoneName = await FlutterTimezone.getLocalTimezone();
       tz.setLocalLocation(tz.getLocation(timeZoneName));
     } catch (_) {
       tz.setLocalLocation(tz.getLocation('UTC'));

--- a/lib/features/prayer_times/data/services/prayer_notification_service.dart
+++ b/lib/features/prayer_times/data/services/prayer_notification_service.dart
@@ -1,6 +1,6 @@
 import 'package:adhan/adhan.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
@@ -14,7 +14,7 @@ class PrayerNotificationService {
     if (_initialized) return;
     tz.initializeTimeZones();
     try {
-      final String timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
+      final String timeZoneName = await FlutterTimezone.getLocalTimezone();
       tz.setLocalLocation(tz.getLocation(timeZoneName));
     } catch (_) {
       tz.setLocalLocation(tz.getLocation('UTC'));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   http: ^1.3.0
   youtube_explode_dart: ^2.3.6
   flutter_local_notifications: ^18.0.1
-  flutter_native_timezone: ^2.0.0
+  flutter_timezone: ^1.0.6
   shared_preferences: ^2.5.1
   just_audio: ^0.9.45
   just_audio_background: ^0.0.1-beta.17


### PR DESCRIPTION
## Summary
- replace the flutter_native_timezone dependency with flutter_timezone
- update the adhkar reminder and prayer notification services to import flutter_timezone and use its API

## Testing
- flutter pub get *(fails: Flutter SDK is not available in the execution environment)*
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*
- flutter test *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3ae73650832a960d616e7eeacf02