### PR TITLE
Vendor flutter_timezone plugin and update binding

### DIFF
--- a/packages/flutter_timezone/android/build.gradle
+++ b/packages/flutter_timezone/android/build.gradle
@@ -1,0 +1,51 @@
+group 'net.wolverinebeach.flutter_timezone'
+version '1.0.8'
+
+buildscript {
+    ext.kotlin_version = '1.9.24'
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    namespace 'net.wolverinebeach.flutter_timezone'
+    compileSdk 35
+
+    defaultConfig {
+        minSdk 21
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+}

--- a/packages/flutter_timezone/android/src/main/AndroidManifest.xml
+++ b/packages/flutter_timezone/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="net.wolverinebeach.flutter_timezone" />

--- a/packages/flutter_timezone/android/src/main/kotlin/net/wolverinebeach/flutter_timezone/FlutterTimezonePlugin.kt
+++ b/packages/flutter_timezone/android/src/main/kotlin/net/wolverinebeach/flutter_timezone/FlutterTimezonePlugin.kt
@@ -1,0 +1,32 @@
+package net.wolverinebeach.flutter_timezone
+
+import android.content.Context
+import androidx.annotation.NonNull
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.util.TimeZone
+
+class FlutterTimezonePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
+    private lateinit var channel: MethodChannel
+    @Suppress("unused")
+    private lateinit var applicationContext: Context
+
+    override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        applicationContext = flutterPluginBinding.applicationContext
+        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_timezone")
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
+        when (call.method) {
+            "getLocalTimezone" -> result.success(TimeZone.getDefault().id)
+            "getAvailableTimezones" -> result.success(TimeZone.getAvailableIDs().toList())
+            else -> result.notImplemented()
+        }
+    }
+}

--- a/packages/flutter_timezone/lib/flutter_timezone.dart
+++ b/packages/flutter_timezone/lib/flutter_timezone.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+class FlutterTimezone {
+  FlutterTimezone._();
+
+  static const MethodChannel _channel = MethodChannel('flutter_timezone');
+
+  /// Returns the timezone name for the current device.
+  static Future<String> getLocalTimezone() async {
+    final timezone = await _channel.invokeMethod<String>('getLocalTimezone');
+    if (timezone == null) {
+      throw PlatformException(
+        code: 'unavailable',
+        message: 'Timezone information is not available on this device.',
+      );
+    }
+    return timezone;
+  }
+
+  /// Returns the list of available timezone identifiers on the platform.
+  static Future<List<String>> getAvailableTimezones() async {
+    final timezones = await _channel.invokeMethod<List<dynamic>>(
+      'getAvailableTimezones',
+    );
+    if (timezones == null) {
+      return const <String>[];
+    }
+    return timezones.cast<String>();
+  }
+}

--- a/packages/flutter_timezone/pubspec.yaml
+++ b/packages/flutter_timezone/pubspec.yaml
@@ -1,0 +1,23 @@
+name: flutter_timezone
+version: 1.0.8
+description: Platform channel plugin to provide timezone information.
+homepage: https://pub.dev/packages/flutter_timezone
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: net.wolverinebeach.flutter_timezone
+        pluginClass: FlutterTimezonePlugin

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -483,10 +483,9 @@ packages:
   flutter_timezone:
     dependency: "direct main"
     description:
-      name: flutter_timezone
-      sha256: "06b35132c98fa188db3c4b654b7e1af7ccd01dfe12a004d58be423357605fb24"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/flutter_timezone"
+      relative: true
+    source: path
     version: "1.0.8"
   flutter_web_plugins:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
   http: ^1.3.0
   youtube_explode_dart: ^2.3.6
   flutter_local_notifications: ^18.0.1
-  flutter_timezone: ^1.0.6
+  flutter_timezone:
+    path: packages/flutter_timezone
   shared_preferences: ^2.5.1
   just_audio: ^0.9.45
   just_audio_background: ^0.0.1-beta.17


### PR DESCRIPTION
## Summary
- vendor the flutter_timezone 1.0.8 sources into packages/flutter_timezone
- update the Android plugin to set up its method channel from FlutterPlugin.FlutterPluginBinding only
- point the app's pubspec at the vendored plugin copy

## Testing
- flutter pub get *(fails: flutter command not found in environment)*
- flutter build apk *(fails: flutter command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd56b4e350832aaa8b437440304ec3