### PR TITLE
Add offline caching for wallpapers and image downloads

### DIFF
--- a/lib/features/wallpapers/data/models/blog_image.dart
+++ b/lib/features/wallpapers/data/models/blog_image.dart
@@ -3,4 +3,23 @@ class BlogImage {
   final String imageUrl;
 
   BlogImage({required this.title, required this.imageUrl});
+
+  factory BlogImage.fromJson(Map<String, dynamic> json) {
+    final imageUrl = json['imageUrl'] as String? ?? '';
+    if (imageUrl.isEmpty) {
+      throw const FormatException('imageUrl is required');
+    }
+
+    return BlogImage(
+      title: json['title'] as String? ?? 'بدون عنوان',
+      imageUrl: imageUrl,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'imageUrl': imageUrl,
+    };
+  }
 }

--- a/lib/features/wallpapers/data/services/wallpapers_service.dart
+++ b/lib/features/wallpapers/data/services/wallpapers_service.dart
@@ -1,6 +1,9 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
 import 'package:xml/xml.dart';
 
 import '../models/blog_image.dart';
@@ -19,39 +22,27 @@ class WallpapersService {
 
   static const String _baseFeedUrl =
       'https://appstaki.blogspot.com/feeds/posts/default';
+  static const String _cacheFileName = 'wallpapers_cache.json';
+  static const String _imageCacheFolderName = 'wallpapers_images';
 
   final http.Client _client;
 
   Future<List<BlogImage>> fetchWallpapers() async {
-    const pageSize = 100;
-    var startIndex = 1;
-    final images = <BlogImage>[];
+    final cachedImages = await loadCachedWallpapers();
 
     try {
-      while (true) {
-        final response = await _client.get(
-          _buildFeedUri(maxResults: pageSize, startIndex: startIndex),
-        );
-        if (response.statusCode != 200) {
-          throw WallpapersException(
-            'فشل في جلب الخلفيات (رمز الاستجابة: ${response.statusCode})',
-          );
-        }
-
-        final page = _parseFeed(response.body);
-        images.addAll(page.images);
-
-        if (page.entryCount < pageSize) {
-          break;
-        }
-
-        startIndex += pageSize;
-      }
-
-      return images;
+      final remoteImages = await _fetchWallpapersFromNetwork();
+      await _saveWallpapersToCache(remoteImages);
+      return remoteImages;
     } on WallpapersException {
+      if (cachedImages.isNotEmpty) {
+        return cachedImages;
+      }
       rethrow;
     } catch (error, stackTrace) {
+      if (cachedImages.isNotEmpty) {
+        return cachedImages;
+      }
       Error.throwWithStackTrace(
         WallpapersException('تعذر معالجة بيانات الخلفيات: $error'),
         stackTrace,
@@ -60,11 +51,71 @@ class WallpapersService {
   }
 
   Future<Uint8List> downloadImageBytes(String url) async {
+    final file = await ensureImageFile(url);
+    return await file.readAsBytes();
+  }
+
+  Future<File?> getCachedImageFile(String url) async {
+    final file = await _getImageCacheFile(url);
+    if (await file.exists()) {
+      return file;
+    }
+    return null;
+  }
+
+  Future<File> ensureImageFile(String url) async {
+    final file = await _getImageCacheFile(url);
+    if (await file.exists()) {
+      return file;
+    }
+
     final response = await _client.get(Uri.parse(url));
     if (response.statusCode != 200) {
       throw WallpapersException('فشل تحميل الصورة (${response.statusCode})');
     }
-    return response.bodyBytes;
+
+    await file.writeAsBytes(response.bodyBytes, flush: true);
+    return file;
+  }
+
+  Future<List<BlogImage>> loadCachedWallpapers() async {
+    try {
+      final file = await _getCacheFile();
+      if (!await file.exists()) {
+        return [];
+      }
+
+      final jsonString = await file.readAsString();
+      if (jsonString.trim().isEmpty) {
+        return [];
+      }
+
+      final decoded = jsonDecode(jsonString);
+      if (decoded is! List) {
+        return [];
+      }
+
+      final images = <BlogImage>[];
+      for (final entry in decoded) {
+        if (entry is Map<String, dynamic>) {
+          try {
+            images.add(BlogImage.fromJson(entry));
+          } catch (_) {
+            continue;
+          }
+        } else if (entry is Map) {
+          try {
+            images.add(BlogImage.fromJson(Map<String, dynamic>.from(entry)));
+          } catch (_) {
+            continue;
+          }
+        }
+      }
+
+      return images;
+    } catch (_) {
+      return [];
+    }
   }
 
   Uri _buildFeedUri({required int maxResults, required int startIndex}) {
@@ -94,5 +145,62 @@ class WallpapersService {
     }
 
     return (images: images, entryCount: entries.length);
+  }
+
+  Future<List<BlogImage>> _fetchWallpapersFromNetwork() async {
+    const pageSize = 100;
+    var startIndex = 1;
+    final images = <BlogImage>[];
+
+    while (true) {
+      final response = await _client.get(
+        _buildFeedUri(maxResults: pageSize, startIndex: startIndex),
+      );
+      if (response.statusCode != 200) {
+        throw WallpapersException(
+          'فشل في جلب الخلفيات (رمز الاستجابة: ${response.statusCode})',
+        );
+      }
+
+      final page = _parseFeed(response.body);
+      images.addAll(page.images);
+
+      if (page.entryCount < pageSize) {
+        break;
+      }
+
+      startIndex += pageSize;
+    }
+
+    return images;
+  }
+
+  Future<void> _saveWallpapersToCache(List<BlogImage> images) async {
+    try {
+      final file = await _getCacheFile();
+      if (!await file.parent.exists()) {
+        await file.parent.create(recursive: true);
+      }
+      final encoded = jsonEncode(images.map((image) => image.toJson()).toList());
+      await file.writeAsString(encoded, flush: true);
+    } catch (_) {
+      // Ignored: caching failure shouldn't break the flow.
+    }
+  }
+
+  Future<File> _getCacheFile() async {
+    final directory = await getApplicationDocumentsDirectory();
+    return File('${directory.path}/$_cacheFileName');
+  }
+
+  Future<File> _getImageCacheFile(String url) async {
+    final tempDir = await getTemporaryDirectory();
+    final cacheDir = Directory('${tempDir.path}/$_imageCacheFolderName');
+    if (!await cacheDir.exists()) {
+      await cacheDir.create(recursive: true);
+    }
+
+    final fileName = base64Url.encode(utf8.encode(url)).replaceAll('=', '');
+    return File('${cacheDir.path}/$fileName.jpg');
   }
 }


### PR DESCRIPTION
## Summary
- persist fetched wallpapers to a local JSON cache and reuse cached image files when available
- update WallpapersCubit to surface cached wallpapers offline and reuse cached files for share/download/wallpaper actions
- configure tests with a fake path provider and cover offline fallbacks

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6578337c832abe459be54b343c65