### PR TITLE
Cache support directory for audio service

### DIFF
--- a/lib/core/services/audio_service.dart
+++ b/lib/core/services/audio_service.dart
@@ -17,6 +17,8 @@ class AudioService {
 
   final AudioPlayer _audioPlayer;
   final Map<String, YoutubeAudioCacheEntry> _youtubeCache = {};
+  late final Future<Directory> _applicationSupportDirectoryFuture =
+      getApplicationSupportDirectory();
 
   StreamSubscription<ProcessingState>? _processingStateSubscription;
   StreamSubscription<bool>? _playingStreamSubscription;
@@ -103,7 +105,7 @@ class AudioService {
       );
     }
 
-    final Directory dir = await getApplicationSupportDirectory();
+    final Directory dir = await _applicationSupportDirectoryFuture;
     final String filePath = '${dir.path}/${supplication.title}.mp3';
     if (await File(filePath).exists()) {
       return AudioSource.file(


### PR DESCRIPTION
## Summary
- cache the application support directory future when constructing `AudioService`
- reuse the cached directory when building audio sources so the lookup runs only once

## Testing
- flutter test *(fails: `flutter` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce32e11794832a9a24bfe9f4a8ea0c